### PR TITLE
changes img_url to gif_url in db

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :development, :test do
   gem 'pry', '~> 0.14.1'
   gem 'shoulda-matchers', '~> 6.0'
   gem 'simplecov', require: false, group: :test
+  gem 'faraday'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,12 @@ GEM
     docile (1.4.1)
     drb (2.2.1)
     erubi (1.13.0)
+    faraday (2.12.0)
+      faraday-net_http (>= 2.0, < 3.4)
+      json
+      logger
+    faraday-net_http (3.3.0)
+      net-http
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.6)
@@ -104,6 +110,7 @@ GEM
     irb (1.14.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    json (2.7.5)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
     logger (1.6.1)
@@ -121,6 +128,8 @@ GEM
     minitest (5.25.1)
     msgpack (1.7.3)
     mutex_m (0.2.0)
+    net-http (0.4.1)
+      uri
     net-imap (0.5.0)
       date
       net-protocol
@@ -225,6 +234,7 @@ GEM
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uri (0.13.1)
     webrick (1.8.2)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -242,6 +252,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   debug
+  faraday
   jsonapi-serializer
   pg (~> 1.1)
   pry (~> 0.14.1)

--- a/db/migrate/20241101154136_rename_img_url_to_gif_url_in_pokemons.rb
+++ b/db/migrate/20241101154136_rename_img_url_to_gif_url_in_pokemons.rb
@@ -1,0 +1,5 @@
+class RenameImgUrlToGifUrlInPokemons < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :pokemons, :img_url, :gif_url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_31_204309) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_01_154136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "pokemons", force: :cascade do |t|
     t.string "name"
     t.string "description"
-    t.string "img_url"
+    t.string "gif_url"
     t.string "cry_url"
     t.string "small_img"
     t.integer "level"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,7 @@ Trainer.create!(
 Pokemon.create!(
     name:"Gastly",
     description: "spooky boi",
-    img_url: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/showdown/shiny/92.gif",
+    gif_url: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/showdown/shiny/92.gif",
     cry_url: "https://raw.githubusercontent.com/PokeAPI/cries/main/cries/pokemon/latest/92.ogg",
     small_img: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/92.png",
     level: 1,
@@ -29,7 +29,7 @@ Pokemon.create!(
 Pokemon.create!(
     name:"Charmander",
     description: "hot lil doggy",
-    img_url: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/showdown/shiny/4.gif",
+    gif_url: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/showdown/shiny/4.gif",
     cry_url: "https://raw.githubusercontent.com/PokeAPI/cries/main/cries/pokemon/latest/4.ogg",
     small_img: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/shiny/4.png",
     level: 1,
@@ -43,7 +43,7 @@ Pokemon.create!(
 Pokemon.create!(
     name: "Magikarp",
     description: "In the distant past, it was somewhat stronger than the horribly weak descendants that exist today.",
-    img_url: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/showdown/129.gif",
+    gif_url: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/showdown/129.gif",
     cry_url: "https://raw.githubusercontent.com/PokeAPI/cries/main/cries/pokemon/latest/129.ogg",
     small_img: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/129.png",
     level: 1,
@@ -57,7 +57,7 @@ Pokemon.create!(
 Pokemon.create!(
     name: "Shinx",
     description: "This Pokémon generates electricity by contracting\nits muscles. Excited trembling is a sign that Shinx\nis generating a tremendous amount of electricity.",
-    img_url: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/showdown/shiny/403.gif",
+    gif_url: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/showdown/shiny/403.gif",
     cry_url: "https://raw.githubusercontent.com/PokeAPI/cries/main/cries/pokemon/latest/403.ogg",
     small_img: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/shiny/403.png",
     level: 5,
@@ -67,42 +67,3 @@ Pokemon.create!(
     happiness: 80,
     trainer_id: 1
 )
-
-# Pokemon.create!(
-#     name:"gastly",
-#     description: "",
-#     img_url: "",
-#     cry_url: "",
-#     small_img: "",
-#     level: 0,
-#     xp: 0,
-#     energy: 0,
-#     max_energy: 0,
-#     happiness: 0
-# )
-
-# Pokemon.create!(
-#     name:"gastly",
-#     description: "",
-#     img_url: "",
-#     cry_url: "",
-#     small_img: "",
-#     level: 0,
-#     xp: 0,
-#     energy: 0,
-#     max_energy: 0,
-#     happiness: 0
-# )
-
-# Pokemon.create!(
-#     name:"gastly",
-#     description: "",
-#     img_url: "",
-#     cry_url: "",
-#     small_img: "",
-#     level: 0,
-#     xp: 0,
-#     energy: 0,
-#     max_energy: 0,
-#     happiness: 0
-# )


### PR DESCRIPTION
A very small PR that simply changes the img_url db column name to gif_url for clarity. It also changes the seed data to match, and adds the Faraday gem for making calls to external API.